### PR TITLE
basic docker-compose script for backends.

### DIFF
--- a/backend/Docker/docker-compose.yml
+++ b/backend/Docker/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '2.1'
+services:
+  postgresql:
+    image: postgres:11-alpine
+    container_name: butcher_postgresql
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=butcher
+      - POSTGRES_PASSWORD=butcher
+    networks:
+      - frontend
+      - backend
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U butcher" ]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+  redis:
+    image: redis:6-alpine
+    container_name: butcher_redis
+    networks:
+      - frontend
+      - backend
+    ports:
+      - "6380:6380"
+  migration:
+    build: 'flyway'
+    container_name: butcher_flyway
+    networks:
+      - backend
+    volumes:
+      - ../src/main/resources/sql/migration:/flyway/sql
+    depends_on:
+      postgresql:
+        condition: service_healthy
+networks:
+  frontend:
+  backend:

--- a/backend/Docker/flyway/Dockerfile
+++ b/backend/Docker/flyway/Dockerfile
@@ -1,0 +1,5 @@
+FROM flyway/flyway:7.0-alpine
+
+CMD ["migrate"]
+
+COPY flyway.conf /flyway/conf/flyway.conf

--- a/backend/Docker/flyway/flyway.conf
+++ b/backend/Docker/flyway/flyway.conf
@@ -1,0 +1,3 @@
+flyway.url=jdbc:postgresql://postgresql:5432/butcher
+flyway.user=butcher
+flyway.password=butcher


### PR DESCRIPTION
PR contains the following `docker-compose` configuration:
* PostgreSQL on port 5432
* Redis on port 6380
* Flyway container executing `migrate` on startup